### PR TITLE
Pin third-party GitHub Actions to SHAs and limit editor-copy publishing

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -23,7 +23,7 @@ jobs:
     # Note: No caching for this build!
 
     - name: "Update Archive"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       env:
         ARCHIVE_FULL: ${{ inputs.archive_full }}
       with:
@@ -31,7 +31,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       with:
         make: gh-archive
         token: ${{ github.token }}

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -14,6 +14,9 @@ on:
     - LICENSE.md
     - .gitignore
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: "Update Editor's Copy"

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -39,12 +39,12 @@ jobs:
         restore-keys: i-d-
 
     - name: "Build Drafts"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       with:
         token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       if: ${{ github.event_name == 'push' }}
       with:
         make: gh-pages

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -2,6 +2,8 @@ name: "Update Editor's Copy"
 
 on:
   push:
+    branches:
+    - main
     paths-ignore:
     - README.md
     - CONTRIBUTING.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,12 @@ jobs:
         restore-keys: i-d-
 
     - name: "Build Drafts"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       with:
         token: ${{ github.token }}
 
     - name: "Upload to Datatracker"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       with:
         make: upload
       env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Update Generated Files"
-      uses: martinthomson/i-d-template@v1
+      uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5
       with:
         make: update-files
         token: ${{ github.token }}


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.
- Granted `contents: write` to the editor-copy workflow, which already pushes generated GitHub Pages output.

Changed workflows:

- `.github/workflows/archive.yml`
- `.github/workflows/ghpages.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/update.yml`

Resolved refs:

- `martinthomson/i-d-template@v1` -> `martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows

Follow-up update:

- The push-triggered editor-copy job failed when updating `gh-pages`; added explicit `contents: write` for that workflow and re-pushed.

Follow-up update:

- Limited generated `gh-pages` publishing to `main` pushes. Pull requests still build and upload artifacts, but feature-branch pushes no longer try to publish unsigned generated commits.
